### PR TITLE
exit gracefully if no chart data

### DIFF
--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -125,6 +125,11 @@ class ChartModule
 
 		tag = templaterState.textInsideTag.substr(1) # tag to be replaced
 		chartData = scopeManager.getValueFromScope(tag) # data to build chart from
+
+		# exit gracefully if no chartData, required when outer loop data doesn't exist
+		# note getValueFromScope actually returns a string called 'undefined' - argg!
+		return if (chartData=='undefined')
+
 		# create a unique filename so we can have multiple charts from one tag, via the loop functionality in docxtemplater
 		# Note the +1 isn't really required, it just makes the number the same as the associated rel, handy for debugging the resulting docx	
 		filename = tag + (this.chartManager.maxRid + 1);


### PR DESCRIPTION
The main docxtemplater loop functionality allows for a situation where the loop element is missing - this allows for sections of the template to be skipped programmatically. The chart module errors out if a chart tag is included inside such an empty loop. This fix exits gracefully in that scenario. 
