### PR TITLE
Remove docUtils used from docxtemplater

### DIFF
--- a/coffee/chartManager.coffee
+++ b/coffee/chartManager.coffee
@@ -22,7 +22,7 @@ module.exports = class ChartManager
 
 		file = loadFile("word/_rels/#{@endFileName}.xml.rels") || loadFile("word/_rels/document.xml.rels") #duct tape hack, doesn't work otherwise
 		return if file == undefined
-		content = DocUtils.decode_utf8(file.asText())
+		content = DocUtils.decodeUtf8(file.asText())
 		@xmlDoc = DocUtils.Str2xml(content)
 		RidArray = ((parseInt tag.getAttribute("Id").substr(3)) for tag in @xmlDoc.getElementsByTagName('Relationship')) #Get all Rids
 		@maxRid = DocUtils.maxArray(RidArray)
@@ -40,7 +40,7 @@ module.exports = class ChartManager
 		@_addChartRelationship(@maxRid, chartName);
 		@_addChartContentType(chartName);
 
-		@zip.file(@filePath, DocUtils.encode_utf8(DocUtils.xml2Str(@xmlDoc)), {})
+		@zip.file(@filePath, DocUtils.encodeUtf8(DocUtils.xml2Str(@xmlDoc)), {})
 		return @maxRid
 
 	###*
@@ -64,7 +64,7 @@ module.exports = class ChartManager
 	_addChartContentType: (name) ->
 		path = '[Content_Types].xml'
 		file = @zip.files[path]
-		content = DocUtils.decode_utf8(file.asText())
+		content = DocUtils.decodeUtf8(file.asText())
 		xmlDoc = DocUtils.Str2xml(content)
 		types = xmlDoc.getElementsByTagName("Types")[0]
 		newTag = xmlDoc.createElement('Override')
@@ -72,4 +72,4 @@ module.exports = class ChartManager
 		newTag.setAttribute('ContentType', 'application/vnd.openxmlformats-officedocument.drawingml.chart+xml')
 		newTag.setAttribute('PartName', "/word/charts/#{name}.xml")
 		types.appendChild(newTag)
-		@zip.file(path, DocUtils.encode_utf8(DocUtils.xml2Str(xmlDoc)), {})
+		@zip.file(path, DocUtils.encodeUtf8(DocUtils.xml2Str(xmlDoc)), {})

--- a/coffee/docUtils.coffee
+++ b/coffee/docUtils.coffee
@@ -1,16 +1,46 @@
 DOMParser = require('xmldom').DOMParser
 XMLSerializer= require('xmldom').XMLSerializer
 
-DocUtils= require('docxtemplater').DocUtils
+DocUtils = {}
 
 DocUtils.xml2Str = (xmlNode) ->
 	a = new XMLSerializer()
 	a.serializeToString(xmlNode)
 
-DocUtils.Str2xml = (str, errorHandler) ->
+DocUtils.Str2xml= (str,errorHandler) ->
 	parser = new DOMParser({errorHandler})
-	xmlDoc = parser.parseFromString(str, "text/xml")
+	xmlDoc=parser.parseFromString(str,"text/xml")
 
 DocUtils.maxArray = (a) -> Math.max.apply(null, a)
 
-module.exports = DocUtils
+DocUtils.decodeUtf8 = (s) ->
+	try
+		if s==undefined then return undefined
+		return decodeURIComponent(escape(DocUtils.convertSpaces(s))) #replace Ascii 160 space by the normal space, Ascii 32
+	catch e
+		console.error s
+		console.error 'could not decode'
+		throw new Error('end')
+
+DocUtils.encodeUtf8 = (s)->
+	unescape(encodeURIComponent(s))
+
+DocUtils.convertSpaces = (s) ->
+	s.replace(new RegExp(String.fromCharCode(160),"g")," ")
+
+DocUtils.pregMatchAll = (regex, content) ->
+	###regex is a string, content is the content. It returns an array of all matches with their offset, for example:
+	regex=la
+	content=lolalolilala
+	returns: [{0:'la',offset:2},{0:'la',offset:8},{0:'la',offset:10}]
+	###
+	regex= (new RegExp(regex,'g')) unless (typeof regex=='object')
+	matchArray= []
+	replacer = (match,pn ..., offset, string)->
+		pn.unshift match #add match so that pn[0] = whole match, pn[1]= first parenthesis,...
+		pn.offset= offset
+		matchArray.push pn
+	content.replace regex,replacer
+	matchArray
+
+module.exports=DocUtils


### PR DESCRIPTION
The docUtils methods are not part of the api and are no more going to be exposed into the API.

See : https://github.com/open-xml-templating/docxtemplater/commit/c429d33231ca4851c2d6f0990486fecb53f4de0f

These methods are deprecated since version 1.1.0 of docxtemplater, and they will be removed in the next major version.
