### PR TITLE
Support docxtemplater v2+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 test/
 js/
 node_modules
+.idea/

--- a/coffee/index.coffee
+++ b/coffee/index.coffee
@@ -151,7 +151,7 @@ class ChartModule
 		chart.writeFile(filename)
 		
 		
-		tagXml = @manager.getInstance('xmlTemplater').tagXml
+		tagXml = @manager.getInstance('xmlTemplater').fileTypeConfig.tagsXmlArray[0]
 
 		newText = @getChartXml({
 			chartID: chartId,

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "chart"
   ],
   "devDependencies": {
-    "chai": "^1.10.0",
-    "gulp": "~3.8.0",
-    "gulp-coffee": "~2.0.1",
-    "gulp-uglify": "~0.3.0",
-    "gulp-watch": "~0.6.5"
+    "chai": "^3.5.0",
+    "gulp": "~3.9.1",
+    "gulp-coffee": "~2.3.2",
+    "gulp-uglify": "~1.5.3",
+    "gulp-watch": "~4.3.5"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docxtemplater-chart-module",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Chart Module for docxtemplater v1.0",
   "main": "js/index.js",
   "scripts": {
@@ -28,7 +28,7 @@
   "author": "Danila Dergachev <gnomdan@yandex.ru>",
   "license": "MIT",
   "dependencies": {
-    "docxtemplater": "^1.0.5",
+    "docxtemplater": "^2.1.0",
     "gulp-browserify": "^0.5.0",
     "jszip": "^2.4.0",
     "xmldom": "^0.1.19"


### PR DESCRIPTION
This fixes the breaking API change for docxtemplater v2+.  

Fixes #7 
